### PR TITLE
#10 add temperature degree component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "normalize.css": "^8.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@100;400;500;600;700&display=swap" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -24,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Weather App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/Temperature/Temperature.module.css
+++ b/src/components/Temperature/Temperature.module.css
@@ -1,0 +1,12 @@
+.value {
+  font-size: 14.4rem;
+  font-weight: 500;
+  line-height: 16.9rem;
+}
+
+.scale {
+  font-size: 4.8rem;
+  font-weight: 500;
+  line-height: 5.6rem;
+  color: #a09fb1;
+}

--- a/src/components/Temperature/index.tsx
+++ b/src/components/Temperature/index.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react'
+import styles from './Temperature.module.css'
+
+interface ITemperature {
+  scale?: 'fahrenheit' | 'celsius'
+  value: string | number
+}
+
+export const Temperature: FC<ITemperature> = ({ scale = 'celsius', value }) => {
+  return (
+    <>
+      <span className={styles.value}>{value}</span>
+      <span className={styles.scale}>
+        &deg;{scale === 'celsius' ? 'C' : 'F'}
+      </span>
+    </>
+  )
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,1 @@
+export { Temperature } from './Temperature'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { App } from './App'
 
+import 'normalize.css'
+
 ReactDOM.render(
   <React.StrictMode>
     <App />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { App } from './App'
 
 import 'normalize.css'
+import './styles/main.css'
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,10 @@
+html {
+  font-size: 62.5%;
+}
+
+body {
+  font-size: 1.6rem;
+  font-family: 'Raleway', sans-serif;
+  line-height: 1.4;
+  color: #e7e7eb;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8051,6 +8051,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+normalize.css@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"


### PR DESCRIPTION
closes #10 

Added following functionality:
* Added normalize.css to reset default browser styles;
* Added Raleway font to the project hosted by Google Fonts;
* I have added the following Properties:
	* Added a `value` property that will display the temperature degrees number;
	* Added a `scale` property that can be either `celsius` or `fahrenheit`, default is `celsius`;

Component is used like this:
```typescript
<Temperature value={15} scale="celsius" />
```

![Screen Shot 2020-11-10 at 6 01 31 PM](https://user-images.githubusercontent.com/12704461/98659157-d1582b80-237e-11eb-938c-76f957233e1d.png)