### PR TITLE
[#32] Add PercentageBar component

### DIFF
--- a/src/components/PercentageBar/PercentageBar.module.css
+++ b/src/components/PercentageBar/PercentageBar.module.css
@@ -1,0 +1,46 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.percentages {
+  display: flex;
+  justify-content: space-between;
+  color: var(--color-primary-dark);
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.bars {
+  position: relative;
+  margin: 0.2rem 0 0.4rem 0;
+}
+
+.bars .filled,
+.bars .empty {
+  height: 0.8rem;
+  border-radius: 8rem;
+}
+
+.bars .filled {
+  position: relative;
+  z-index: 2;
+  background-color: var(--yellow-1);
+}
+
+.bars .empty {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 100%;
+  background-color: var(--color-primary-light);
+}
+
+.percentageFooter {
+  align-self: flex-end;
+  color: var(--color-primary-dark);
+  font-weight: 700;
+  font-size: 1.2rem;
+}

--- a/src/components/PercentageBar/index.tsx
+++ b/src/components/PercentageBar/index.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react'
+import styles from './PercentageBar.module.css'
+
+interface IPercentageBar {
+  percentage: number
+}
+
+export const PercentageBar: FC<IPercentageBar> = ({ percentage }) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.percentages}>
+        <span>0</span>
+        <span>50</span>
+        <span>100</span>
+      </div>
+      <div className={styles.bars}>
+        <div className={styles.filled} style={{ width: `${percentage}%` }} />
+        <div className={styles.empty} />
+      </div>
+      <div className={styles.percentageFooter}>%</div>
+    </div>
+  )
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -10,5 +10,6 @@
   --gray-3: #585676;
   --gray-2: #6e707a;
   --gray-1: #88869d;
+  --yellow-1: #ffec65;
   --white: white;
 }


### PR DESCRIPTION
closes #32 

I renamed this component to `PercentageBar`. I think that makes more sense since it's responsible for rendering a given percentage and can be used for other things than humidity as well.

I added the following properties:

* `percentage`, which is basically the percentage of the yellow bar to be filled;

This component is 100% in width, meaning that the parent component takes care of how wide it will be e.g. in the `HighlightCard`.

Component is used the following way:

```jsx
<PercentageBar percentage={40} />
```

<img width="740" alt="Screen Shot 2020-11-26 at 10 49 52 PM" src="https://user-images.githubusercontent.com/12704461/100365104-01b7ef00-303a-11eb-805e-f71225860fde.png">